### PR TITLE
Fix `last` and `last_` for effectful streams

### DIFF
--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -1250,11 +1250,11 @@ iterateM f = loop where
 
 last :: Monad m => Stream (Of a) m r -> m (Of (Maybe a) r)
 last = loop Nothing_ where
-  loop m str = case str of
-    Return r            -> case m of
+  loop mb str = case str of
+    Return r            -> case mb of
       Nothing_ -> return (Nothing :> r)
       Just_ a  -> return (Just a :> r)
-    Effect m            -> m >>= last
+    Effect m            -> m >>= loop mb
     Step (a :> rest)  -> loop (Just_ a) rest
 {-#INLINABLE last #-}
 
@@ -1262,11 +1262,11 @@ last = loop Nothing_ where
 
 last_ :: Monad m => Stream (Of a) m r -> m (Maybe a)
 last_ = loop Nothing_ where
-  loop m str = case str of
-    Return r            -> case m of
+  loop mb str = case str of
+    Return r            -> case mb of
       Nothing_ -> return Nothing
       Just_ a  -> return (Just a)
-    Effect m            -> m >>= last_
+    Effect m            -> m >>= loop mb
     Step (a :> rest)  -> loop (Just_ a) rest
 {-#INLINABLE last_ #-}
 


### PR DESCRIPTION
I think I found an issue with the functions `last` and `last_` in `Streaming.Prelude`.
When applied to a stream of lines read from a file they return `Nothing` independent of whether the file contains any lines or not.

---

Previously those functions would forget the most recent value whenever
they encountered an effect.

E.g.

    λ> runResourceT $ Streaming.Prelude.last $ Streaming.Prelude.readFile "LICENSE"
    Nothing :> ()

Instead of the expected

    λ> runResourceT $ Streaming.Prelude.last $ Streaming.Prelude.readFile "LICENSE"
    Just "SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE." :> ()