### PR TITLE
Add differently-constrained maps and mapped

### DIFF
--- a/src/Streaming.hs
+++ b/src/Streaming.hs
@@ -24,6 +24,7 @@ module Streaming
    mapsM2,
    mapped,
    mapped2,
+   hoistUnexposed,
    distribute,
    groups,
 

--- a/src/Streaming.hs
+++ b/src/Streaming.hs
@@ -19,8 +19,11 @@ module Streaming
 
    -- * Transforming streams
    maps,
+   maps2,
    mapsM,
+   mapsM2,
    mapped,
+   mapped2,
    distribute,
    groups,
 

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -95,7 +95,9 @@ module Streaming.Prelude (
     , map
     , mapM
     , maps
+    , maps2
     , mapped
+    , mapped2
     , for
     , with
     , subst
@@ -1351,6 +1353,14 @@ mapped :: (Monad m, Functor f) => (forall x . f x -> m (g x)) -> Stream f m r ->
 mapped = mapsM
 {-#INLINE mapped #-}
 
+{-| A version of 'mapped' that imposes a 'Functor' constraint on the target functor rather
+    than the source functor. This version should be preferred if 'fmap' on the target
+    functor is cheaper.
+
+-}
+mapped2 :: (Monad m, Functor g) => (forall x . f x -> m (g x)) -> Stream f m r -> Stream g m r
+mapped2 = mapsM2
+{-# INLINE mapped2 #-}
 
 {-| Fold streamed items into their monoidal sum
 


### PR DESCRIPTION
Sometimes, the target functor of `maps` or `mapped` offers
a more efficient `fmap` than the source functor. Add versions
of `maps`, `mapped`, and `mapsM` that use that one instead.