### PR TITLE
Make zipsWith short-circuit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+- ???
+
+    Made `zipsWith` and allied functions short-circuit; if the
+    first stream is empty, ignore the second one.
+
 - 0.1.3.0 
 
     Added `duplicate` and `store` for simultaneous folding.

--- a/src/Streaming.hs
+++ b/src/Streaming.hs
@@ -40,6 +40,7 @@ module Streaming
 
    -- * Zipping, unzipping, separating and unseparating streams
    zipsWith,
+   zipsWith',
    zips,
    unzips,
    interleaves,
@@ -133,7 +134,10 @@ import Data.Bifunctor
 
 >   chunksOf     :: Int -> Stream f m r -> Stream (Stream f m) m r
 >   splitsAt     :: Int -> Stream f m r -> Stream f m (Stream f m r)
->   zipsWith     :: (forall x y. f x -> g y -> h (x, y)) -> Stream f m r -> Stream g m r -> Stream h m r
+>   zipsWith     :: (forall x y. f x -> g y -> h (x, y))
+                 -> Stream f m r -> Stream g m r -> Stream h m r
+>   zipsWith'    :: (forall x y p. (x -> y -> p) -> f x -> g y -> h p)
+                 -> Stream f m r -> Stream g m r -> Stream h m r
 >   intercalates :: Stream f m () -> Stream (Stream f m) m r -> Stream f m r
 >   unzips       :: Stream (Compose f g) m r ->  Stream f (Stream g m) r
 >   separate     :: Stream (Sum f g) m r -> Stream f (Stream g) m r  -- cp. partitionEithers


### PR DESCRIPTION
    * Make `zipsWith` stop running effects in the second stream
      if the first is empty. This makes `mplus` satisfy the left
      catch `MonadPlus` law.
    
    * Take advantage of any purity in the streams to avoid
      inserting `Effect` constructors or performing monadic
      operations unnecessarily.
    
    * Remove the now-unnecessary `Functor f` and `Functor g` constraints
      from `zipsWith`. I have verified that I can write an equivalent
      version of `zipsWith` for `FreeT` without those, so there shouldn't
      be any compatibility issues.
    
    * Remove the unnecessary `Functor` constraint from `inspect`. This
      too is unnecessary for the (almost trivial) `FreeT` version.
    
    Fixes #38