### PR TITLE
GHC 8 compat: Semigroup is a superclass of Monoid

### DIFF
--- a/src/Data/Functor/Of.hs
+++ b/src/Data/Functor/Of.hs
@@ -16,6 +16,12 @@ data Of a b = !a :> b
               Read, Show, Traversable, Typeable)
 infixr 5 :>
 
+#if MIN_VERSION_base(4,11,0)
+instance (Semigroup a, Semigroup b) => Semigroup (Of a b) where
+  (m :> w) <> (m' :> w') = (m <> m') :> (w <> w')
+  {-#INLINE (<>) #-}
+#endif
+
 instance (Monoid a, Monoid b) => Monoid (Of a b) where
   mempty = mempty :> mempty
   {-#INLINE mempty #-}

--- a/src/Streaming/Internal.hs
+++ b/src/Streaming/Internal.hs
@@ -218,6 +218,12 @@ instance (Applicative f, Monad m) => Alternative (Stream f m) where
   str <|> str' = zipsWith (liftA2 (,)) str str'
   {-#INLINE (<|>) #-}
 
+#if MIN_VERSION_base(4,11,0)
+instance (Functor f, Monad m, Semigroup w) => Semigroup (Stream f m w) where
+  a <> b = a >>= \w -> fmap (w <>) b
+  {-#INLINE (<>) #-}
+#endif
+
 instance (Functor f, Monad m, Monoid w) => Monoid (Stream f m w) where
   mempty = return mempty
   {-#INLINE mempty #-}


### PR DESCRIPTION
This fails compiling with recent versions of GHC due to a missing
Semigroup instance for Stream. But at the same time, we don't want to
pull in the `semigroups` package for older GHC - so just make the
instance conditional for versions of base which contain a definition of
Data.Semigroup.